### PR TITLE
Update to Node 20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v1
       with:
-        node-version: '16.x'
+        node-version: '20.x'
     - name: Setup dependencies
       run: |
         npm install -g @vercel/ncc

--- a/action.yml
+++ b/action.yml
@@ -8,5 +8,5 @@ outputs:
   number:
     description: 'Number of pull request'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Node 16 has been EOL-ed and should be updated to Node 20.
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/