### PR TITLE
GitHub Actionのruntimeをnode24に移行

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v1
       with:
-        node-version: '20.x'
+        node-version: '24.x'
     - name: Setup dependencies
       run: |
         npm install -g @vercel/ncc

--- a/action.yml
+++ b/action.yml
@@ -8,5 +8,5 @@ outputs:
   number:
     description: 'Number of pull request'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
### 対応内容
GitHub Actionのruntimeをnode24に移行

### 背景
既に node24 が利用可能になっているので移行したい、という背景です。
( 現行の node20 は2026年4月にEOLとなるため )